### PR TITLE
Product search should use key words with && operator, not with ||

### DIFF
--- a/server/routes/routesUtilities.js
+++ b/server/routes/routesUtilities.js
@@ -12,7 +12,7 @@ var buildQuery = function(requestQuery){
 			tagsRegExp[i] = new RegExp(tagsString[i], 'i');
 		}
 		
-		query.tags = {$in:tagsRegExp};
+		query.tags = {$all:tagsRegExp};
 	}
 
 	query = _.omit(query, ['querySort', 'queryLimit', 'page']);


### PR DESCRIPTION
- Using mongo 'al'l query operator array to match all values from tags

Closes #72 